### PR TITLE
Add ECO-Reward notification & fix

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -13,8 +13,6 @@ name: Publish to GitHub Packages
 run-name: 'Package Publish #${{github.run_number}}'
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -36,7 +34,7 @@ jobs:
           distribution: 'oracle'
 
       - name: Publish to GitHub Packages Apache Maven
-        run: ./gradlew publish -i
+        run: ./gradlew publishToGithubPackage
         env:
           MAVEN_PUBLISH_URL: https://maven.pkg.github.com/${{github.repository}}
           MAVEN_PUBLISH_USERNAME: ${{github.actor}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff
 .idea/
+.vscode/
 
 *.iml
 *.ipr

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
                 jdk "jdk17"
             }
             steps {
-                sh './gradlew publish'
+                sh './gradlew publishToNyaaCatCILocal'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+
 # PlayTimeTracker
 Playtime tracking plugin for ~~Bukkit/Spigot~~ PaperMC
+
 
 ## Configuration
 
@@ -58,6 +60,122 @@ missions:
 5. **If you modified `gradle.properties` under this repo, When committing changes, make sure to remove what you add in step 3. so that `GITHUB_TOKEN` is not exposed.**
 
 
+## Change Log
+
+### 0.9-SNAPSHOT
+
+- [Tech] port to 1.21.1 and CI migration;
+- [Tech] publish to github packages
+- **[BREAKING] Abandon support for other Bukkit/Spigot, Only support PaperMC ** 
+
+  we don't have enough effort for different distributions
+
+### 0.10-alpha.1
+
+- [Feature] **Rewards storage & any-time acquire**: Now rewards will be record when a mission is completed, and you can use `/ptt acquire` to acquire it at anytime, no need to worry about missing it!
+
+- [Feature/WIP] Reward Module instead of use command all the time. Currently only support ECO Rewards. Command Rewards and Item Rewards are WIP.
+
+- [Feature] Add `/ptt listrewards <missionName|all>` to show rewards awaiting for acquiring.
+
+- [Configuration] `missions.yml` :
+
+  ```yaml
+  missions:
+    eco:
+      __class__: cat.nyaa.playtimetracker.config.data.MissionData
+      group: []
+      expression: lastSeen>1&&dailyTime>1&&weeklyTime>1&&monthlyTime>1&&totalTime>1&&1==2
+      reset-daily: true
+      reset-weekly: false
+      reset-monthly: false
+      reward-list: # can be multiple rewards; the key is not important, but reward will be executed in key order
+        reward1:
+          __class__: cat.nyaa.playtimetracker.config.data.EcoRewardData
+          type: TRANSFER  # TRANSFER, ADD
+          ref-vault: $system # "$system" or player uuid
+          ratio: 0.01
+          min: 1.0
+          max: 1024.0
+          vault: $system # "$system" or player uuid  # same as /eco transfer 0.01:1:1024:$system $system %player_name%
+      notify: true
+    daily:
+      __class__: cat.nyaa.playtimetracker.config.data.MissionData
+      group: []
+      expression: dailyTime>3600000
+      reset-daily: true
+      reset-weekly: false
+      reset-monthly: false
+      reward-list:
+        reward2:
+          __class__: cat.nyaa.playtimetracker.config.data.EcoRewardData
+          type: ADD
+          amount: 100 # same as /eco add 100 %player%
+      notify: true
+  ```
+
+- [Configuration] lang
+
+  - `command.listrewards.*`
+  - `manual.listrewards.*`
+
+  ```yaml
+  command:
+    listrewards:
+      show_all: 有 %s 个任务奖励待领取
+      show: 有 %s 个 %s 任务奖励待领取
+      empty_all: 没有可以领取的任务奖励
+      empty: 没有可以领取的 %s 任务奖励
+  manual:
+    listrewards:
+      description: 查看所有奖励
+      usage: /ptt listrewards <奖励名称|all>
+  ```
+
+- [Tech] Add some Unit Tests.
+
+- [Tech] Recover to use NyaaCat CI
+
+### 0.10-alpha.2
+
+- [Feature] Add notification for ECO Rewards. Now when acquire ECO Rewards, it displays how much you get.
+
+- [Feature] `/ptt listrewards all` now display detailed information of how many rewards for each mission.
+
+- [Configuration] lang
+
+  - `command.listrewards.err`
+
+  - `command.listrewards.show_item`
+
+  - `message.reward.notify` for login notification
+
+  - `message.reward.eco` for ECO Rewards acquiring detailed information
+
+  ```yaml
+  command:
+    listrewards:
+      err: 查询失败
+      show_item: "- 任务 %s: %s"  # first %s is mission name; second %s is rewards count
+  message:
+    reward:
+      notify:
+        command: /ptt acquire
+        msg: 您有 %s 个任务奖励可以领取
+      eco:
+        success: 经济奖励%s%s已经添加到您的账户  # first %s is amount; second %s is eco-unit
+  ```
+
+- [Fix] Database wrapper log
+
+- [Fix] remove `NotifyAcquireTask` since it should not work.
+
+- [Fix] pipeline for github-package and NyaaCat CI
+
+- [Tech/WIP] PaperMC Adventure for messages instead of legacy Bukkit API
+
+
+
 ## TODO
 
 #### 0.10-alpha
@@ -69,13 +187,17 @@ missions:
 
 - [ ] add reward module: command
 - [ ] add reward module: item
-- [ ] logging system
+- [x] logging system
+- [ ] i18n: https://docs.papermc.io/paper/dev/component-api/i18n#examples
+- [ ] mission completion notification (sound or Advancement)
 
 #### 1.0
-
+- [ ] Use time-wheel instead of 1gt polling
+   - [ ] Optimize Expressions
+   - [ ] calculate next mission completion time
+   - [ ] time-wheel for mission completion
+   - [ ] command for querying next mission completion time
 - [ ] Make all db operations async
    - [ ] Remove `cat.nyan.playtimetracker.db.connection`
    - [ ] Make `CachedXXXTable` and async methods
-- [ ] Use time-wheel instead of 1gt polling
-- [ ] Optimize Expressions
-
+- [ ] disable plugin: self-disable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ val paperApiName = "1.21.1-R0.1-SNAPSHOT"
 
 // Version used for distribution. Different from maven repo
 group = "cat.nyaa"
-version = "0.10-alpha.1"
+version = "0.10-alpha.2"
 
 java {
     // Configure the java toolchain. This allows gradle to auto-provision JDK 21 on systems that only have JDK 8 installed for example.
@@ -69,7 +69,7 @@ publishing {
     }
     repositories {
         maven {
-            name = "maven-publish"
+            name = "GithubPackage"
             url = uri(System.getenv("MAVEN_PUBLISH_URL") ?: layout.buildDirectory.dir("repo"))
             val mavenUsername = System.getenv("MAVEN_PUBLISH_USERNAME")
             val mavenPassword = System.getenv("MAVEN_PUBLISH_PASSWORD")
@@ -80,7 +80,22 @@ publishing {
                 }
             }
         }
+        maven {
+            name = "NyaaCatCILocal"
+            //local maven repository
+            url = uri("file://${System.getenv("MAVEN_DIR")}")
+        }
     }
+}
+
+// Custom tasks for publishing to specific repositories
+tasks.register("publishToGithubPackage") {
+    dependsOn("publishMavenJavaPublicationToGithubPackageRepository")
+    // auto generated task: publish<PublicationName>PublicationTo<RepositoryName>Repository
+}
+
+tasks.register("publishToNyaaCatCILocal") {
+    dependsOn("publishMavenJavaPublicationToNyaaCatCILocalRepository")
 }
 
 

--- a/src/main/java/cat/nyaa/playtimetracker/PlayTimeTracker.java
+++ b/src/main/java/cat/nyaa/playtimetracker/PlayTimeTracker.java
@@ -36,6 +36,8 @@ public final class PlayTimeTracker extends JavaPlugin implements IEconomyCorePro
     @Nullable
     private TimeRecordManager timeRecordManager;
     @Nullable
+    private PlayerRewardManager rewardManager;
+    @Nullable
     private PlayerMissionManager missionManager;
     @Nullable
     private Plugin essentialsPlugin;
@@ -94,8 +96,10 @@ public final class PlayTimeTracker extends JavaPlugin implements IEconomyCorePro
         this.afkManager = new PlayerAFKManager(this);
         //record
         this.timeRecordManager = new TimeRecordManager(this, databaseManager.getTimeTrackerConnection());
+        //reward
+        this.rewardManager = new PlayerRewardManager(this, databaseManager.getRewardsConnection());
         //Mission
-        this.missionManager = new PlayerMissionManager(this, pttConfiguration, timeRecordManager, databaseManager.getCompletedMissionConnection(), databaseManager.getRewardsConnection());
+        this.missionManager = new PlayerMissionManager(this, pttConfiguration, timeRecordManager, rewardManager, databaseManager.getCompletedMissionConnection());
     }
 
     @Nullable
@@ -121,6 +125,11 @@ public final class PlayTimeTracker extends JavaPlugin implements IEconomyCorePro
     @Nullable
     public TimeRecordManager getTimeRecordManager() {
         return timeRecordManager;
+    }
+
+    @Nullable
+    public PlayerRewardManager getRewardManager() {
+        return rewardManager;
     }
 
     @Nullable

--- a/src/main/java/cat/nyaa/playtimetracker/PlayerRewardManager.java
+++ b/src/main/java/cat/nyaa/playtimetracker/PlayerRewardManager.java
@@ -1,0 +1,199 @@
+package cat.nyaa.playtimetracker;
+
+import cat.nyaa.playtimetracker.config.data.EcoRewardData;
+import cat.nyaa.playtimetracker.config.data.ISerializableExt;
+import cat.nyaa.playtimetracker.db.connection.RewardsConnection;
+import cat.nyaa.playtimetracker.db.model.RewardDbModel;
+import cat.nyaa.playtimetracker.db.tables.RewardsTable;
+import cat.nyaa.playtimetracker.db.utils.RewardDbModelIterator;
+import cat.nyaa.playtimetracker.reward.EcoReward;
+import cat.nyaa.playtimetracker.reward.IReward;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+public class PlayerRewardManager {
+
+    private final Plugin plugin;
+    private final RewardsTable rewardsTable;
+    private ConcurrentHashMap<UUID, String> playerAcquiringRewards;
+
+    public PlayerRewardManager(Plugin plugin, RewardsConnection rewardsConnection) {
+        this.plugin = plugin;
+        this.rewardsTable = rewardsConnection.getRewardsTable();
+        this.playerAcquiringRewards = new ConcurrentHashMap<>();
+    }
+
+    public void putRewardAsync(final Player player, final String missionName, final long completedTime, final Iterable<IReward> rewards, final @Nullable BiConsumer<Player, String> notifyCallback) {
+        final var scheduler = this.plugin.getServer().getScheduler();
+        final var logger = this.plugin.getLogger();
+        scheduler.runTaskAsynchronously(this.plugin, () -> {
+            var it = new RewardDbModelIterator(player.getUniqueId(), missionName, completedTime, rewards.iterator());
+            this.rewardsTable.insertRewardBatch(it);
+            if (notifyCallback != null) {
+                scheduler.runTask(this.plugin, () -> notifyCallback.accept(player, missionName));
+            }
+        });
+    }
+
+    public void putRewardAsync(final Player player, final String missionName, final long completedTime, final List<ISerializableExt> rewardDataList, final @Nullable BiConsumer<Player, String> notifyCallback) {
+        final var logger = this.plugin.getSLF4JLogger();
+        List<IReward> rewardList = new ArrayList<>(rewardDataList.size());
+        for (ISerializableExt rewardData : rewardDataList) {
+            IReward reward = this.createReward(rewardData);
+            if(reward != null) {
+                if(reward.prepare(missionName, completedTime, player, this.plugin)) {
+                    rewardList.add(reward);
+                } else {
+                    logger.error("[PlayerRewardManager] Failed to prepare reward {} for {} {}", reward.getClass(), player.getUniqueId(), missionName);
+                }
+            } else {
+                logger.error("[PlayerRewardManager] Unknown reward data type {} for {} {}", rewardData.getClass(), player.getUniqueId(), missionName);
+            }
+        }
+        this.putRewardAsync(player, missionName, completedTime, rewardList, notifyCallback);
+    }
+
+    public void executeDistributeRewardsAsync(final Player player, final @Nullable String missionName) {
+        final var scheduler = this.plugin.getServer().getScheduler();
+        final var logger = this.plugin.getSLF4JLogger();
+        scheduler.runTaskAsynchronously(this.plugin, () -> {
+            final var rewardList = this.rewardsTable.selectRewards(player.getUniqueId(), missionName);
+            if(rewardList.isEmpty()) {
+                scheduler.runTask(this.plugin, () -> {
+                    if(missionName == null) {
+                        I18n.send(player, "command.acquire.empty");
+                    } else {
+                        I18n.send(player, "command.acquire.not_found", missionName);
+                    }
+                    this.playerAcquiringRewards.remove(player.getUniqueId());
+                });
+            } else {
+                logger.info("[PlayerRewardManager] Player {} is acquiring {} rewards", player.getUniqueId(), rewardList.size());
+                scheduler.runTask(this.plugin, () -> {
+                    IntArrayList rewardIdList = new IntArrayList(rewardList.size());
+                    ObjectArrayList<Component> outputMessages = new ObjectArrayList<>(16);
+                    for (RewardDbModel reward : rewardList) {
+                        Boolean distributeRet = reward.getReward().distribute(player, this.plugin, outputMessages);
+                        if(distributeRet == null) {
+                            logger.warn("[PlayerRewardManager] Player {} blocked acquire reward {}", player.getUniqueId(), reward.getId());
+                            // TODO: send message to player?
+                            break;
+                        } else {
+                            var builder = Component.text();
+                            if (distributeRet) {
+                                rewardIdList.add(reward.getId());
+                                // TODO: I18n
+                                String successText = I18n.format("command.acquire.success", reward.getRewardName());
+                                builder.append(LegacyComponentSerializer.legacySection().deserialize(successText));
+                            } else {
+                                String failText = I18n.format("command.acquire.failed", reward.getRewardName());
+                                builder.append(LegacyComponentSerializer.legacySection().deserialize(failText));
+                            }
+                            if(!outputMessages.isEmpty()) {
+                                builder.append(Component.text(' '));
+                                for (Component outputMessage : outputMessages) {
+                                    builder.append(outputMessage);
+                                }
+                            }
+                            player.sendMessage(builder.build());
+                        }
+                        outputMessages.clear();
+                    }
+                    if(rewardIdList.isEmpty()) {
+                        this.playerAcquiringRewards.remove(player.getUniqueId());
+                    } else {
+                        scheduler.runTaskAsynchronously(this.plugin, () -> {
+                            this.rewardsTable.deleteRewardBatch(rewardIdList);
+                            this.playerAcquiringRewards.remove(player.getUniqueId());
+                            logger.info("[PlayerRewardManager] Player {} has acquired {} rewards", player.getUniqueId(), rewardIdList.size());
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+    public void executeListRewardsAsync(final Player player, final @Nullable String rewardName) {
+        final var scheduler = this.plugin.getServer().getScheduler();
+        final var logger = this.plugin.getSLF4JLogger();
+        scheduler.runTaskAsynchronously(this.plugin, () -> {
+            if(rewardName == null) {
+                Object2IntMap<String> missions = this.rewardsTable.selectRewardsCount(player.getUniqueId());
+                scheduler.runTask(this.plugin, () -> {
+                    if(missions == null) {
+                        I18n.send(player, "command.listrewards.err");
+                    } else if(missions.isEmpty()) {
+                        I18n.send(player, "command.listrewards.empty_all");
+                    } else {
+                        int count = missions.values().intStream().sum();
+                        String header = I18n.format("command.listrewards.show_all",count);
+                        var builder = Component.text();
+                        builder.append(LegacyComponentSerializer.legacySection().deserialize(header));
+                        for(var entry : missions.object2IntEntrySet()) {
+                            String line = I18n.format("command.listrewards.show_item", entry.getKey(), entry.getIntValue());
+                            builder.append(Component.newline());
+                            builder.append(LegacyComponentSerializer.legacySection().deserialize(line));
+                        }
+                        player.sendMessage(builder.build());
+                    }
+                });
+            } else {
+                int count = this.rewardsTable.selectRewardsCount(player.getUniqueId(), rewardName);
+                scheduler.runTask(this.plugin, () -> {
+                    if(count == 0) {
+                        I18n.send(player, "command.listrewards.empty", rewardName);
+                    } else {
+                        I18n.send(player, "command.listrewards.show", count, rewardName);
+                    }
+                });
+            }
+        });
+    }
+
+    public void executeRewardsAutoCheckAsync(final Player player, int delayTicks) {
+        final var scheduler = this.plugin.getServer().getScheduler();
+        final var logger = this.plugin.getSLF4JLogger();
+        scheduler.runTaskAsynchronously(this.plugin, () -> {
+            final var rewardList = this.rewardsTable.selectRewardsCount(player.getUniqueId());
+            if (rewardList == null) {
+                logger.error("[PlayerRewardManager] Failed to auto-check rewards count for player {}", player.getUniqueId());
+            } else if(rewardList.isEmpty()){
+
+            } else {
+                final int totalRewards = rewardList.values().intStream().sum();
+                scheduler.runTaskLater(this.plugin, () -> {
+                    String header = I18n.format("message.reward.notify.msg", totalRewards);
+                    String cmd = I18n.format("message.reward.notify.command");
+                    var builder = Component.text();
+                    builder.append(LegacyComponentSerializer.legacySection().deserialize(header));
+                    builder.append(
+                        Component.text()
+                                .content(cmd)
+                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, cmd))
+                    );
+                    player.sendMessage(builder.build());
+                }, delayTicks);
+            }
+        });
+    }
+
+    public IReward createReward(ISerializableExt data) {
+        if(data instanceof EcoRewardData ecoRewardData) {
+            return new EcoReward(ecoRewardData);
+        }
+        return null;
+    }
+}

--- a/src/main/java/cat/nyaa/playtimetracker/command/CommandHandler.java
+++ b/src/main/java/cat/nyaa/playtimetracker/command/CommandHandler.java
@@ -17,7 +17,6 @@ import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.time.ZonedDateTime;
-import java.util.Set;
 import java.util.UUID;
 
 public class CommandHandler extends CommandReceiver {
@@ -163,12 +162,12 @@ public class CommandHandler extends CommandReceiver {
             I18n.send(sender, "command.only-player-can-do");
             return;
         }
-        PlayerMissionManager missionManager = plugin.getMissionManager();
+        PlayerRewardManager missionManager = plugin.getRewardManager();
         if (missionManager == null) {
             I18n.send(sender, "command.acquire.err");
             return;
         }
-        missionManager.showPlayerRewards(player, missionName, false);
+        missionManager.executeListRewardsAsync(player, "all".equals(missionName) ? null : missionName);
     }
 
     @SubCommand(value = "acquire", alias = {"ac"}, permission = "ptt.command.acquire")
@@ -178,12 +177,12 @@ public class CommandHandler extends CommandReceiver {
             I18n.send(sender, "command.only-player-can-do");
             return;
         }
-        PlayerMissionManager missionManager = plugin.getMissionManager();
+        PlayerRewardManager missionManager = plugin.getRewardManager();
         if (missionManager == null) {
             I18n.send(sender, "command.acquire.err");
             return;
         }
-        missionManager.executeAcquire(player, missionName);
+        missionManager.executeDistributeRewardsAsync(player, "all".equals(missionName) ? null : missionName);
 //        Set<String> missionNameSet = missionManager.getAwaitingMissionNameSet(player);
 //        if (missionName.equals("all")) {
 //            if (missionNameSet.isEmpty()) {

--- a/src/main/java/cat/nyaa/playtimetracker/config/MissionConfig.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/MissionConfig.java
@@ -4,12 +4,14 @@ import cat.nyaa.nyaacore.configuration.FileConfigure;
 import cat.nyaa.playtimetracker.PlayTimeTracker;
 import cat.nyaa.playtimetracker.config.data.ISerializableExt;
 import cat.nyaa.playtimetracker.config.data.MissionData;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MissionConfig extends FileConfigure {
@@ -38,9 +40,15 @@ public class MissionConfig extends FileConfigure {
     @Override
     public void load() {
         super.load();
-        for (MissionData missionData : missions.values()) {
-            if(!missionData.validate()) {
-                throw new RuntimeException("Invalid mission data");
+        List<String> outputError = new ObjectArrayList<>(4);
+        for (var mission : missions.entrySet()) {
+            if(!mission.getValue().validate(outputError)) {
+                outputError.add("Invalid mission data: " + mission.getKey());
+                StringBuilder sb = new StringBuilder("Parse error in MissionConfig: ");
+                for (int i = outputError.size() - 1; i >= 0; i--) {
+                    sb.append("\r\n\t").append(outputError.get(i));
+                }
+                throw new RuntimeException(sb.toString());
             }
         }
     }

--- a/src/main/java/cat/nyaa/playtimetracker/config/data/EcoRewardData.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/data/EcoRewardData.java
@@ -3,6 +3,7 @@ package cat.nyaa.playtimetracker.config.data;
 import cat.nyaa.nyaacore.configuration.ISerializable;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.UUID;
 
 public class EcoRewardData implements ISerializableExt {
@@ -31,27 +32,32 @@ public class EcoRewardData implements ISerializableExt {
     }
 
     @Override
-    public boolean validate() {
+    public boolean validate(List<String> outputError) {
         if(!isRefVaultSystemVault()) {
             try {
                 refVaultUUID = UUID.fromString(refVault);
             } catch (IllegalArgumentException e) {
+                outputError.add("Invalid ref-vault (should be UUID or \"$system\"): " + refVault);
                 return false;
             }
         }
         if(ratio < 0.0 || ratio > 1.0) {
+            outputError.add("Invalid ratio (should be in [0.0, 1.0]): " + ratio);
             return false;
         }
         if(min < 0.0 || max < 0.0 || min > max) {
+            outputError.add("Invalid min/max: " + min + "/" + max);
             return false;
         }
         if(amount < 0.0) {
+            outputError.add("Invalid amount (should be non-negative): " + amount);
             return false;
         }
         if(!isVaultSystemVault()) {
             try {
                 vaultUUID = UUID.fromString(vault);
             } catch (IllegalArgumentException e) {
+                outputError.add("Invalid vault (should be UUID or \"$system\"): " + vault);
                 return false;
             }
         }

--- a/src/main/java/cat/nyaa/playtimetracker/config/data/ISerializableExt.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/data/ISerializableExt.java
@@ -2,11 +2,15 @@ package cat.nyaa.playtimetracker.config.data;
 
 import cat.nyaa.nyaacore.configuration.ISerializable;
 
+import java.util.List;
+
 public interface ISerializableExt extends ISerializable {
 
     /**
      * Validate the data in the object. may modify un-serilizable fields.
+     * @param outputError a list to store the error message.
+     *                    will be read from end to start.
      * @return true if the data is valid, false otherwise.
      */
-    boolean validate();
+    boolean validate(List<String> outputError);
 }

--- a/src/main/java/cat/nyaa/playtimetracker/config/data/MissionData.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/data/MissionData.java
@@ -35,13 +35,14 @@ public class MissionData implements ISerializableExt {
     }
 
     @Override
-    public boolean validate() {
+    public boolean validate(List<String> outputError) {
         List<ISerializableExt> sortedList = new ArrayList<>(rewardList.size());
         var keys = rewardList.keySet().stream().sorted().iterator();
         while (keys.hasNext()) {
             var key = keys.next();
             var reward = rewardList.get(key);
-            if(reward == null || !reward.validate()) {
+            if(reward == null || !reward.validate(outputError)) {
+                outputError.add("Invalid reward: " + key);
                 return false;
             }
             sortedList.add(reward);

--- a/src/main/java/cat/nyaa/playtimetracker/db/connection/CompletedMissionConnection.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/connection/CompletedMissionConnection.java
@@ -14,7 +14,7 @@ public class CompletedMissionConnection {
     private final CompletedMissionTable completedMissionTable;
 
     public CompletedMissionConnection(HikariDataSource ds, Plugin plugin) {
-        this.completedMissionTable = new CompletedMissionTable(ds);
+        this.completedMissionTable = new CompletedMissionTable(ds, plugin.getSLF4JLogger());
         this.completedMissionTable.tryCreateTable(plugin);
     }
 

--- a/src/main/java/cat/nyaa/playtimetracker/db/connection/RewardsConnection.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/connection/RewardsConnection.java
@@ -10,7 +10,7 @@ public class RewardsConnection {
     
     public RewardsConnection(HikariDataSource ds, Plugin plugin) {
         this.plugin = plugin;
-        this.rewardsTable = new RewardsTable(ds);
+        this.rewardsTable = new RewardsTable(ds, plugin.getSLF4JLogger());
         this.rewardsTable.tryCreateTable(plugin);
     }
 

--- a/src/main/java/cat/nyaa/playtimetracker/db/connection/TimeTrackerConnection.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/connection/TimeTrackerConnection.java
@@ -20,7 +20,7 @@ public final class TimeTrackerConnection {
 
     public TimeTrackerConnection(HikariDataSource ds, Plugin plugin) {
         this.plugin = plugin;
-        this.timeTrackerTable = new TimeTrackerTable(ds);
+        this.timeTrackerTable = new TimeTrackerTable(ds, plugin.getSLF4JLogger());
         this.timeTrackerTable.tryCreateTable(plugin);
     }
 

--- a/src/main/java/cat/nyaa/playtimetracker/db/tables/CompletedMissionTable.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/tables/CompletedMissionTable.java
@@ -18,13 +18,13 @@ import java.util.UUID;
 
 public class CompletedMissionTable {
 
-    private static final Logger logger = LoggerFactory.getLogger(CompletedMissionTable.class);
-
     public static final String TABLE_NAME = "completed";
     private final HikariDataSource ds;
+    private final Logger logger;
 
-    public CompletedMissionTable(HikariDataSource ds) {
+    public CompletedMissionTable(HikariDataSource ds, Logger logger) {
         this.ds = ds;
+        this.logger = logger;
     }
 
     public boolean tryCreateTable(Plugin plugin) {

--- a/src/main/java/cat/nyaa/playtimetracker/db/tables/TimeTrackerTable.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/tables/TimeTrackerTable.java
@@ -17,14 +17,14 @@ import java.util.UUID;
 
 public class TimeTrackerTable {
 
-    private static final Logger logger = LoggerFactory.getLogger(TimeTrackerTable.class);
-
     public static final String TABLE_NAME = "time";
 
     private final HikariDataSource ds;
+    private final Logger logger;
 
-    public TimeTrackerTable(HikariDataSource ds) {
+    public TimeTrackerTable(HikariDataSource ds, Logger logger) {
         this.ds = ds;
+        this.logger = logger;
     }
 
     public boolean tryCreateTable(Plugin plugin) {

--- a/src/main/java/cat/nyaa/playtimetracker/db/utils/RewardDbModelIterator.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/utils/RewardDbModelIterator.java
@@ -1,0 +1,46 @@
+package cat.nyaa.playtimetracker.db.utils;
+
+import cat.nyaa.playtimetracker.db.model.RewardDbModel;
+import cat.nyaa.playtimetracker.reward.IReward;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public class RewardDbModelIterator implements Iterator<RewardDbModel>, Iterable<RewardDbModel> {
+    final UUID playerId;
+    final String rewardName;
+    final long completedTime;
+    final Iterator<IReward> iterator;
+
+    public RewardDbModelIterator(UUID playerId, String rewardName, long completedTime, Iterator<IReward> iterator) {
+        this.playerId = playerId;
+        this.rewardName = rewardName;
+        this.completedTime = completedTime;
+        this.iterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.hasNext();
+    }
+
+    @Override
+    public RewardDbModel next() {
+        return new RewardDbModel(0, this.completedTime, this.playerId, this.rewardName, this.iterator.next());
+    }
+
+    @NotNull
+    @Override
+    public Iterator<RewardDbModel> iterator() {
+        return this;
+    }
+
+    @Override
+    public void forEach(Consumer<? super RewardDbModel> action) {
+        while (this.iterator.hasNext()) {
+            action.accept(new RewardDbModel(0, this.completedTime, this.playerId, this.rewardName, this.iterator.next()));
+        }
+    }
+}

--- a/src/main/java/cat/nyaa/playtimetracker/listener/PTTListener.java
+++ b/src/main/java/cat/nyaa/playtimetracker/listener/PTTListener.java
@@ -45,13 +45,15 @@ public class PTTListener implements Listener {
         if (PlayTimeTracker.getInstance() != null) {
             if (PlayTimeTracker.getInstance().getMissionManager() != null) {
                 PlayTimeTracker.getInstance().getMissionManager().checkPlayerMission(event.getPlayer());
-                PlayTimeTracker.getInstance().getMissionManager().showPlayerRewards(event.getPlayer(), null, true);
             }
             if (PlayTimeTracker.getInstance().getTimeRecordManager() != null) {
                 PlayTimeTracker.getInstance().getTimeRecordManager().addPlayer(event.getPlayer());
             }
             if (PlayTimeTracker.getInstance().getAfkManager() != null) {
                 PlayTimeTracker.getInstance().getAfkManager().addPlayer(event.getPlayer());
+            }
+            if(PlayTimeTracker.getInstance().getRewardManager() != null){
+                PlayTimeTracker.getInstance().getRewardManager().executeRewardsAutoCheckAsync(event.getPlayer(), 10);
             }
         }
     }

--- a/src/main/java/cat/nyaa/playtimetracker/reward/DemoReward.java
+++ b/src/main/java/cat/nyaa/playtimetracker/reward/DemoReward.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.Plugin;
 
 import java.io.*;
 import java.time.Instant;
+import java.util.List;
 
 public class DemoReward implements IReward {
 
@@ -39,7 +40,7 @@ public class DemoReward implements IReward {
     }
 
     @Override
-    public Boolean distribute(Player player, Plugin plugin) {
+    public Boolean distribute(Player player, Plugin plugin, List<Component> outputMessages) {
         if(this.message == null) {
             return false;
         }

--- a/src/main/java/cat/nyaa/playtimetracker/reward/IReward.java
+++ b/src/main/java/cat/nyaa/playtimetracker/reward/IReward.java
@@ -1,10 +1,12 @@
 package cat.nyaa.playtimetracker.reward;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 
 public interface IReward {
 
@@ -17,11 +19,17 @@ public interface IReward {
 
     /**
      * distribute the reward to the player
+     * @param player the player to distribute the reward to
+     * @param plugin the plugin
+     * @param outputMessages the messages to be sent to the player;
+     *                       a component message of reward description can be added to the list on success;
+     *                       a component message of error message can be added to the list otherwise;
+     *                       in any cases, no message be put in the list are allowed
      * @return true if the reward is successfully distributed;
      *         false if the reward distribution has failed;
      *         null if the reward distribution is blocked and should be retried later
      */
-    Boolean distribute(Player player, Plugin plugin);
+    Boolean distribute(Player player, Plugin plugin, List<Component> outputMessages);
 
 
     /**

--- a/src/main/java/cat/nyaa/playtimetracker/task/NotifyAcquireTask.java
+++ b/src/main/java/cat/nyaa/playtimetracker/task/NotifyAcquireTask.java
@@ -7,7 +7,7 @@ public class NotifyAcquireTask implements Runnable {
     public void run() {
         if (PlayTimeTracker.getInstance() != null) {
             if (PlayTimeTracker.getInstance().getMissionManager() != null) {
-                PlayTimeTracker.getInstance().getMissionManager().notifyAcquire();
+                //PlayTimeTracker.getInstance().getMissionManager().notifyAcquire();
             }
         }
     }

--- a/src/main/java/cat/nyaa/playtimetracker/task/PTTTaskManager.java
+++ b/src/main/java/cat/nyaa/playtimetracker/task/PTTTaskManager.java
@@ -9,7 +9,7 @@ public class PTTTaskManager {
     private final PTTConfiguration pluginConfiguration;
     private int timeRecordTaskId;
     private int missionCheckTaskId;
-    private int notifyAcquireTaskId;
+    //private int notifyAcquireTaskId;
     private int saveDbTaskId;
 
     public PTTTaskManager(PlayTimeTracker plugin, PTTConfiguration configuration) {
@@ -25,14 +25,14 @@ public class PTTTaskManager {
     private void init() {
         this.timeRecordTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(getPlugin(), new TimeRecordTask(), 1, 1);
         this.missionCheckTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(getPlugin(), new MissionCheckTask(), 1, 1);
-        this.notifyAcquireTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(getPlugin(), new NotifyAcquireTask(), pluginConfiguration.checkAcquireTick, pluginConfiguration.checkAcquireTick);
+        //this.notifyAcquireTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(getPlugin(), new NotifyAcquireTask(), pluginConfiguration.checkAcquireTick, pluginConfiguration.checkAcquireTick);
         this.saveDbTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(getPlugin(), new SaveDbTask(), 20, 20 * 60);
     }
 
     public void destructor() {
         Bukkit.getScheduler().cancelTask(timeRecordTaskId);
         Bukkit.getScheduler().cancelTask(missionCheckTaskId);
-        Bukkit.getScheduler().cancelTask(notifyAcquireTaskId);
+        //Bukkit.getScheduler().cancelTask(notifyAcquireTaskId);
         Bukkit.getScheduler().cancelTask(saveDbTaskId);
         Bukkit.getScheduler().cancelTasks(getPlugin());
     }

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -6,8 +6,10 @@ command:
     not_found: Reward %s Not Found
     success: Successfully acquired reward %s
   listrewards:
+    err: Internal Server Query Failed
     show_all: There are %s reward(s) awaiting for acquiring
     show: There are %s reward(s) of %s awaiting for acquiring
+    show_item: "- mission %s: %s"
     empty_all: No reward for acquiring currently.
     empty: No reward of %s for acquiring currently.
   afkstatus:
@@ -91,6 +93,12 @@ message:
     notify:
       command: /ptt acquire %s
       msg: You may now acquire reward for mission %s
+  reward:
+    notify:
+      command: /ptt acquire
+      msg: You have %s reward(s) awaiting for acquiring
+    eco:
+      success: Economy Reward of %s%s has been added to your account
 time:
   format:
     h: ' hours '

--- a/src/main/resources/lang/zh_CN.yml
+++ b/src/main/resources/lang/zh_CN.yml
@@ -6,7 +6,9 @@ command:
     not_found: 待领取的奖励里面并没有 %s
     success: 成功领取 %s 的奖励
   listrewards:
+    err: 查询失败
     show_all: 有 %s 个任务奖励待领取
+    show_item: "- 任务 %s: %s"
     show: 有 %s 个 %s 任务奖励待领取
     empty_all: 没有可以领取的任务奖励
     empty: 没有可以领取的 %s 任务奖励
@@ -91,6 +93,12 @@ message:
     notify:
       command: /ptt acquire %s
       msg: 您的在线时长已经达成 %s 的任务要求
+  reward:
+    notify:
+      command: /ptt acquire
+      msg: 您有 %s 个任务奖励可以领取
+    eco:
+      success: 经济奖励%s%s已经添加到您的账户
 time:
   format:
     h: ' 小时 '

--- a/src/test/java/cat/nyaa/playtimetracker/db/TestDatabase.java
+++ b/src/test/java/cat/nyaa/playtimetracker/db/TestDatabase.java
@@ -60,7 +60,7 @@ public class TestDatabase {
 
     @Test
     public void testRewardsTable() {
-        RewardsTable rewardsTable = new RewardsTable(ds);
+        RewardsTable rewardsTable = new RewardsTable(ds, logger);
         rewardsTable.tryCreateTable(plugin);
 
         server.setPlayers(3);
@@ -89,11 +89,13 @@ public class TestDatabase {
 
         // test query
         var listP1 = rewardsTable.selectRewards(player1.getUniqueId(), null);
-        var listP1c = rewardsTable.selectRewardsCount(player1.getUniqueId(), null);
-        Assertions.assertEquals(2, listP1c);
+        var listP1c = rewardsTable.selectRewardsCount(player1.getUniqueId());
+        Assertions.assertEquals(2, listP1c.values().intStream().sum());
 
         var listP2 = rewardsTable.selectRewards(player2.getUniqueId(), rewardName1);
+        var listP2c = rewardsTable.selectRewardsCount(player2.getUniqueId(), rewardName1);
         Assertions.assertEquals(1, listP2.size());
+        Assertions.assertEquals(1, listP2c);
 
         logger.info("add new records: {} {} {}", listP1.get(0).id, listP1.get(1).id, listP2.get(0).id);
 
@@ -104,16 +106,16 @@ public class TestDatabase {
         ids.add(listP2.get(0).id);
         rewardsTable.deleteRewardBatch(ids);
 
-        var list01c = rewardsTable.selectRewardsCount(player1.getUniqueId(), null);
-        Assertions.assertEquals(0, list01c);
-        var list02c = rewardsTable.selectRewardsCount(player2.getUniqueId(), null);
-        Assertions.assertEquals(0, list02c);
+        var list01c = rewardsTable.selectRewardsCount(player1.getUniqueId());
+        Assertions.assertEquals(0, list01c.values().intStream().sum());
+        var list02c = rewardsTable.selectRewardsCount(player2.getUniqueId());
+        Assertions.assertEquals(0, list02c.values().intStream().sum());
     }
 
     @Test
     void testCompletedMissionTable() {
 
-        CompletedMissionTable completedMissionTable = new CompletedMissionTable(ds);
+        CompletedMissionTable completedMissionTable = new CompletedMissionTable(ds, logger);
         completedMissionTable.tryCreateTable(plugin);
 
         server.setPlayers(3);
@@ -166,7 +168,7 @@ public class TestDatabase {
 
     @Test
     void testTimeTrackerTable() {
-        TimeTrackerTable timeTrackerTable = new TimeTrackerTable(ds);
+        TimeTrackerTable timeTrackerTable = new TimeTrackerTable(ds, logger);
         timeTrackerTable.tryCreateTable(plugin);
 
         server.setPlayers(3);

--- a/src/test/java/cat/nyaa/playtimetracker/reward/TestRewardOperate.java
+++ b/src/test/java/cat/nyaa/playtimetracker/reward/TestRewardOperate.java
@@ -5,6 +5,8 @@ import be.seeseemelk.mockbukkit.MockPlugin;
 import be.seeseemelk.mockbukkit.ServerMock;
 import cat.nyaa.playtimetracker.DemoPTT;
 import cat.nyaa.playtimetracker.config.data.EcoRewardData;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -14,23 +16,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.List;
 
 public class TestRewardOperate {
 
     private ServerMock server;
     private DemoPTT plugin;
-    private File root;
+    private ObjectArrayList<Component> outputMessages;
 
     @BeforeEach
     void setUp() {
         server = MockBukkit.mock();
         PluginDescriptionFile description = new PluginDescriptionFile("PlayTimeTracker", "1.0.0", DemoPTT.class.getName());
         plugin = MockBukkit.loadWith(DemoPTT.class, description, new Object[0]);
-        root = new File("build");
-        if(!root.isDirectory()) {
-            root = new File("tmp");
-            root.mkdir();
-        }
+        outputMessages = new ObjectArrayList<>();
     }
 
     @AfterEach
@@ -41,12 +40,12 @@ public class TestRewardOperate {
     @Test
     void testEcoReward1() {
         server.setPlayers(2);
-
+        List<String> outputError = new ObjectArrayList<>();
         EcoRewardData ecoRewardData = new EcoRewardData();
         ecoRewardData.min = 10;
         ecoRewardData.max = 500;
         ecoRewardData.ratio = 0.1;
-        Assertions.assertTrue(ecoRewardData.validate());
+        Assertions.assertTrue(ecoRewardData.validate(outputError));
 
         EcoReward ecoReward = new EcoReward(ecoRewardData);
 
@@ -58,19 +57,19 @@ public class TestRewardOperate {
         Assertions.assertEquals(500, ecoReward.getAmount());
         Assertions.assertEquals(DemoPTT.FakeEcore.SYSTEM_BALANCE - 500, plugin.getEconomyCore().getSystemBalance());
 
-        Assertions.assertTrue(ecoReward.distribute(player, plugin));
+        Assertions.assertTrue(ecoReward.distribute(player, plugin, outputMessages));
         Assertions.assertEquals(500, plugin.getEconomyCore().getPlayerBalance(player.getUniqueId()));
     }
 
     @Test
     void testEcoReward2() {
         server.setPlayers(2);
-
+        List<String> outputError = new ObjectArrayList<>();
         EcoRewardData ecoRewardData = new EcoRewardData();
         ecoRewardData.min = 10;
         ecoRewardData.max = 2000;
         ecoRewardData.ratio = 0.15;
-        Assertions.assertTrue(ecoRewardData.validate());
+        Assertions.assertTrue(ecoRewardData.validate(outputError));
 
         EcoReward ecoReward = new EcoReward(ecoRewardData);
 
@@ -82,25 +81,26 @@ public class TestRewardOperate {
         Assertions.assertEquals(1500, ecoReward.getAmount());
         Assertions.assertEquals(DemoPTT.FakeEcore.SYSTEM_BALANCE - 1500, plugin.getEconomyCore().getSystemBalance());
 
-        Assertions.assertFalse(ecoReward.distribute(player, plugin));
+        Assertions.assertFalse(ecoReward.distribute(player, plugin, outputMessages));
         Assertions.assertEquals(DemoPTT.FakeEcore.SYSTEM_BALANCE, plugin.getEconomyCore().getSystemBalance());
     }
 
     @Test
     void testEcoReward3() {
         server.setPlayers(3);
+
         Player player0 = server.getPlayer(1);
         Player player1 = server.getPlayer(2);
         plugin.getEconomyCore().setPlayerBalance(player0.getUniqueId(), 100);
         plugin.getEconomyCore().setPlayerBalance(player1.getUniqueId(), 200);
-
+        List<String> outputError = new ObjectArrayList<>();
         EcoRewardData ecoRewardData = new EcoRewardData();
         ecoRewardData.min = 10;
         ecoRewardData.max = 500;
         ecoRewardData.ratio = 0.1;
         ecoRewardData.vault = player0.getUniqueId().toString();
         ecoRewardData.refVault = player1.getUniqueId().toString();
-        Assertions.assertTrue(ecoRewardData.validate());
+        Assertions.assertTrue(ecoRewardData.validate(outputError));
 
         EcoReward ecoReward = new EcoReward(ecoRewardData);
 
@@ -112,8 +112,31 @@ public class TestRewardOperate {
         Assertions.assertEquals(20, ecoReward.getAmount());
         Assertions.assertEquals(100 - 20, plugin.getEconomyCore().getPlayerBalance(player0.getUniqueId()));
 
-        Assertions.assertTrue(ecoReward.distribute(player, plugin));
+        Assertions.assertTrue(ecoReward.distribute(player, plugin, outputMessages));
         Assertions.assertEquals(20, plugin.getEconomyCore().getPlayerBalance(player.getUniqueId()));
+    }
+
+    @Test
+    void testEcoReward4() {
+        server.setPlayers(2);
+        List<String> outputError = new ObjectArrayList<>();
+        EcoRewardData ecoRewardData = new EcoRewardData();
+        ecoRewardData.type = EcoRewardData.RewardType.ADD;
+        ecoRewardData.amount = 45;
+        Assertions.assertTrue(ecoRewardData.validate(outputError));
+
+        EcoReward ecoReward = new EcoReward(ecoRewardData);
+
+        Player player = server.getPlayer(0);
+        long completedTime = System.currentTimeMillis();
+
+        Assertions.assertTrue(ecoReward.prepare("reward1", completedTime, player, plugin));
+
+        Assertions.assertEquals(45, ecoReward.getAmount());
+        Assertions.assertEquals(DemoPTT.FakeEcore.SYSTEM_BALANCE, plugin.getEconomyCore().getSystemBalance());
+
+        Assertions.assertTrue(ecoReward.distribute(player, plugin, outputMessages));
+        Assertions.assertEquals(45, plugin.getEconomyCore().getPlayerBalance(player.getUniqueId()));
     }
 }
 


### PR DESCRIPTION
## Change Log
### 0.10-alpha.2   / 20240901

- [Feature] Add notification for ECO Rewards. Now when acquire ECO Rewards, it displays how much you get.

- [Feature] `/ptt listrewards all` now display detailed information of how many rewards for each mission.

- [Configuration] lang

  - `command.listrewards.err`

  - `command.listrewards.show_item`

  - `message.reward.notify` for login notification

  - `message.reward.eco` for ECO Rewards acquiring detailed information

  ```yaml
  command:
    listrewards:
      err: 查询失败
      show_item: "- 任务 %s: %s"  # first %s is mission name; second %s is rewards count
  message:
    reward:
      notify:
        command: /ptt acquire
        msg: 您有 %s 个任务奖励可以领取
      eco:
        success: 经济奖励%s%s已经添加到您的账户  # first %s is amount; second %s is eco-unit
  ```

- [Fix] Database wrapper log

- [Fix] remove `NotifyAcquireTask` since it should not work.

- [Fix] pipeline for github-package and NyaaCat CI

- [Tech/WIP] PaperMC Adventure for messages instead of legacy Bukkit API