### PR TITLE
Fix transfer type ECO Reward multi-player completing mission at the same time get decreasing amount of reward  & others

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ missions:
           min: 1.0
           max: 1024.0
           vault: $system # "$system" or player uuid  # same as /eco transfer 0.01:1:1024:$system $system %player_name%
+          sync-ref-cache-time: 12800 # make sure players completing the mission within `sync-ref-cache-time` get the same reward amount (that is, use the same reference vault value). In milliseconds.
       notify: true
     daily:
       __class__: cat.nyaa.playtimetracker.config.data.MissionData
@@ -111,6 +112,10 @@ missions:
           __class__: cat.nyaa.playtimetracker.config.data.EcoRewardData
           type: ADD
           amount: 100 # same as /eco add 100 %player%
+        reward3:
+          __class__: cat.nyaa.playtimetracker.config.data.CommandRewardData
+          pre-command: ''  # command executed immediately when the mission is completed; can be empty string
+          command: /tell %%player_name%% hello, world! # command executed when the reward is acquired
       notify: true
   ```
 
@@ -175,6 +180,27 @@ missions:
 - [Tech/WIP] PaperMC Adventure for messages instead of legacy Bukkit API
 
 
+### 0.10-alpha.3
+
+- [Fix] When use transfer type ECO Reward, if there are multiple players complete the mission at the same time, the reward amount decreases by the order of player list.
+
+- [Feature]  (As the [Fix] Above) Add configuration in `mission.yml` for transfer type ECO reward: 
+
+  `missions[].reward-list[].sync-ref-cache-time` 
+
+  to make sure players completing the mission within `sync-ref-cache-time` get the same reward amount (that is, use the same reference vault value).
+
+  The time unit is milliseconds. Default is 12800 (12.8s = 4 * 64gt). Set to zero or `-1` to disable this feature.
+
+- [Feature] Add Command Rewards. Now you can execute a command when a mission is completed and a reward is acquired.
+
+- [Feature] Add configuration in `mission.yml` for later send information of awaiting rewards when login:
+  
+  `login-check-delay-ticks`
+
+  to make it possible to show this information at the end of login information. The time unit is ticks. Default is 20 (1s).
+
+- [Tech] When distributing rewards, database will delete invalid records so that it will not occupy player's rewards list forever.
 
 ## TODO
 
@@ -185,7 +211,7 @@ missions:
 
 #### 0.10
 
-- [ ] add reward module: command
+- [x] add reward module: command
 - [ ] add reward module: item
 - [x] logging system
 - [ ] i18n: https://docs.papermc.io/paper/dev/component-api/i18n#examples

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ val paperApiName = "1.21.1-R0.1-SNAPSHOT"
 
 // Version used for distribution. Different from maven repo
 group = "cat.nyaa"
-version = "0.10-alpha.2"
+version = "0.10-alpha.3"
 
 java {
     // Configure the java toolchain. This allows gradle to auto-provision JDK 21 on systems that only have JDK 8 installed for example.

--- a/src/main/java/cat/nyaa/playtimetracker/PlayTimeTracker.java
+++ b/src/main/java/cat/nyaa/playtimetracker/PlayTimeTracker.java
@@ -7,6 +7,7 @@ import cat.nyaa.playtimetracker.db.DatabaseManager;
 import cat.nyaa.playtimetracker.listener.ListenerManager;
 import cat.nyaa.playtimetracker.reward.IEconomyCoreProvider;
 import cat.nyaa.playtimetracker.task.PTTTaskManager;
+import cat.nyaa.playtimetracker.utils.Constants;
 import cat.nyaa.playtimetracker.utils.PlaceholderAPIUtils;
 import net.ess3.api.IEssentials;
 import org.bukkit.command.PluginCommand;
@@ -53,6 +54,9 @@ public final class PlayTimeTracker extends JavaPlugin implements IEconomyCorePro
 
     @Override
     public void onEnable() {
+
+        Constants.init(this);
+
         instance = this;
         this.pttConfiguration = new PTTConfiguration(this);
         pttConfiguration.load();

--- a/src/main/java/cat/nyaa/playtimetracker/PlayerMissionManager.java
+++ b/src/main/java/cat/nyaa/playtimetracker/PlayerMissionManager.java
@@ -1,5 +1,6 @@
 package cat.nyaa.playtimetracker;
 
+import cat.nyaa.playtimetracker.config.MissionConfig;
 import cat.nyaa.playtimetracker.config.PTTConfiguration;
 import cat.nyaa.playtimetracker.config.data.MissionData;
 import cat.nyaa.playtimetracker.db.connection.CompletedMissionConnection;
@@ -53,83 +54,6 @@ public class PlayerMissionManager {
     public PlayTimeTracker getPlugin() {
         return plugin;
     }
-
-//    public void getMissionReward(Player player, String mission) {
-//        Map<String, MissionData> missionDataMap = getMissionDataMap();
-//        if (!missionDataMap.containsKey(mission)) return;
-//        I18n.send(player, "message.mission.get_reward", mission);
-//        MissionData missionData = missionDataMap.get(mission);
-//        //item
-//
-//        if (missionData.rewardItemBase64List != null && !missionData.rewardItemBase64List.isEmpty()) {
-//            List<ItemStack> items = new ArrayList<>();
-//            missionData.rewardItemBase64List.forEach(s -> {
-//                try {
-//                    if (s != null && !s.isEmpty())
-//                        items.addAll(ItemStackUtils.itemsFromBase64(s));
-//                } catch (Exception e) {
-//                    e.printStackTrace();
-//                }
-//            });
-//            for (ItemStack item : items) {
-//                if (item == null || item.getType().isAir()) continue;
-//                if (InventoryUtils.hasEnoughSpace(player.getInventory(), item)) {
-//                    InventoryUtils.addItem(player, item);
-//                } else {
-//                    player.getWorld().dropItem(player.getLocation(), item);
-//                }
-//            }
-//        }
-//
-//        //command
-//        if (missionData.rewardCommandList != null)
-//            for (String command : missionData.rewardCommandList) {
-//                if (command != null && !command.isEmpty()) {
-//                    try {
-//                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), PlaceholderAPIUtils.setPlaceholders(player, command));
-//                    } catch (Exception e) {
-//                        e.printStackTrace();
-//                    }
-//                }
-//            }
-//    }
-
-//    public boolean completeMission(@NotNull Player player, String mission) {
-//        if (completeMissionNoReward(player.getUniqueId(), mission)) {
-//            getMissionReward(player, mission);
-//            return true;
-//        }
-//        return false;
-//    }
-
-//    public boolean completeMissionNoReward(UUID playerId, String mission) {
-//        boolean write2db = removeAwaitingReward(playerId, mission);
-//
-//        if (write2db) {
-//            completedMissionConnection.WriteMissionCompleted(playerId, mission, TimeUtils.getUnixTimeStampNow());
-//        }
-//        return write2db;
-//    }
-
-//    public Map<String, MissionData> getMissionDataMap() {
-//        Map<String, MissionData> missionDataMap = new HashMap<>();
-//        getMissionDataList().forEach(missionData -> missionDataMap.put(missionData.missionName, missionData));
-//        return missionDataMap;
-//    }
-
-//    public void checkAwaitingRewardList() {
-//        Map<String, MissionData> missionDataMap = getMissionDataMap();
-//        new ArrayList<>(awaitingRewardList).forEach(
-//                awaitingReward -> {
-//                    if (!missionDataMap.containsKey(awaitingReward.mission)) return;
-//                    if (missionDataMap.get(awaitingReward.mission).timeoutMS < 0) return;
-//                    if ((TimeUtils.getUnixTimeStampNow() - awaitingReward.time) >= missionDataMap.get(awaitingReward.mission).timeoutMS) {
-//                        completeMissionNoReward(awaitingReward.playerId, awaitingReward.mission);
-//                    }
-//                }
-//        );
-//    }
-
 
     public void checkPlayerMission(@NotNull Player player) {
         if (!player.isOnline()) return;
@@ -198,69 +122,9 @@ public class PlayerMissionManager {
         );
     }
 
-//    public Set<String> getAwaitingMissionNameSet(Player player) {
-//        return awaitingRewardList.stream()
-//                .filter(awaitingReward -> awaitingReward.playerId == player.getUniqueId())
-//                .map(awaitingReward -> awaitingReward.mission).collect(Collectors.toSet());
-//    }
-
-//    @Nullable
-//    private AwaitingReward getAwaitingReward(Player player, String missionName) {
-//        for (AwaitingReward awaitingReward : awaitingRewardList) {
-//            if (awaitingReward.playerId == player.getUniqueId() && awaitingReward.mission.equals(missionName)) {
-//                return awaitingReward;
-//            }
-//        }
-//        return null;
-//    }
-
-//    private boolean removeAwaitingReward(UUID playerId, String missionName) {
-//        AtomicBoolean result = new AtomicBoolean(false);
-//        awaitingRewardList.removeIf(awaitingReward -> {
-//                    if (awaitingReward.playerId == playerId
-//                            && awaitingReward.mission.equals(missionName)) {
-//                        result.set(true);
-//                        return true;
-//                    }
-//                    return false;
-//                }
-//        );
-//        return result.get();
-//    }
-
-//    public static IReward createReward(ISerializableExt data) {
-//        if(data instanceof EcoRewardData ecoRewardData) {
-//            return new EcoReward(ecoRewardData);
-//        }
-//        return null;
-//    }
-
-//    private void putAwaitingReward(@NotNull Player player, String missionName, List<ISerializableExt> rewardDataList, boolean notify) {
-//        // TODO
-//        //removeAwaitingReward(player.getUniqueId(), missionName);
-//        // TODO
-//        //awaitingRewardList.add(new AwaitingReward(player.getUniqueId(), missionName, TimeUtils.getUnixTimeStampNow(), notify));
-//        // TODO: Add to completed mission
-//        final long timestamp = TimeUtils.getUnixTimeStampNow();
-//        // TODO: async & cache (completedMissionConnection should run in one thread; another in checkPlayerMission)
-//        this.completedMissionConnection.writeMissionCompleted(player.getUniqueId(), missionName, timestamp);
-//
-//        List<IReward> rewardList = new ArrayList<>(rewardDataList.size());
-//        for (ISerializableExt rewardData : rewardDataList) {
-//            IReward reward = createReward(rewardData);
-//            if(reward != null) {
-//                if(reward.prepare(missionName, timestamp, player, this.plugin)) {
-//                    rewardList.add(reward);
-//                } else {
-//                    this.plugin.getSLF4JLogger().error("Failed to prepare reward {} for {} {}", reward.getClass(), player.getUniqueId(), missionName);
-//                }
-//            } else {
-//                this.plugin.getSLF4JLogger().error("Unknown reward data type {} for {} {}", rewardData.getClass(), player.getUniqueId(), missionName);
-//            }
-//        }
-//
-//        this.playerRewardManager.putPlayerRewardAsync(player, missionName, timestamp, rewardList, notify ? this.notifyAcquire : null);
-//    }
+    public MissionConfig getMissionConfig() {
+        return pttConfiguration.missionConfig;
+    }
 
     public Map<String, MissionData> getMissionDataMap() {
         return pttConfiguration.missionConfig.missions;
@@ -273,136 +137,6 @@ public class PlayerMissionManager {
                 TaskUtils.mod64TickToRun(this.tickNum, player.getUniqueId(), () -> checkPlayerMission(player))
         );
     }
-
-//    public void notifyAcquire(Player player, String mission) {
-//        if(!player.isOnline()) return;
-//        String command = PlaceholderAPIUtils.setPlaceholders(player, I18n.format("message.mission.notify.command", mission));
-//        String msg = PlaceholderAPIUtils.setPlaceholders(player, I18n.format("message.mission.notify.msg", mission));
-//        BaseComponent[] commandComponent = new ComponentBuilder()
-//                .append(msg)
-//                .append(command)
-//                .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command))
-//                .create();
-//        player.spigot().sendMessage(new TextComponent(commandComponent));
-//    }
-
-//    public void notifyAcquire() {
-//        // TODO
-//        awaitingRewardList.forEach(awaitingReward -> {
-//            if (awaitingReward.isNotify) {
-//                Player player = Bukkit.getPlayer(awaitingReward.playerId);
-//                if (player != null) {
-//                    String command = PlaceholderAPIUtils.setPlaceholders(player, I18n.format("message.mission.notify.command", awaitingReward.mission));
-//                    String msg = PlaceholderAPIUtils.setPlaceholders(player, I18n.format("message.mission.notify.msg", awaitingReward.mission));
-//                    BaseComponent[] commandComponent = new ComponentBuilder()
-//                            .append(msg)
-//                            .append(command)
-//                            .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command))
-//                            .create();
-//                    player.spigot().sendMessage(new TextComponent(commandComponent));
-//                }
-//            }
-//        });
-//    }
-
-//    public void executeAcquire(Player player, String mission) {
-//        final UUID playerId = player.getUniqueId();
-//        final String oldMission = playerAcquiringRewards.putIfAbsent(playerId, mission);
-//        if(oldMission != null) {
-//            // database in operate; lock
-//            I18n.send(player, "command.acquire.err");
-//            return;
-//        }
-//        final var scheduler = plugin.getServer().getScheduler();
-//        final String finalMission = "all".equals(mission) ? null : mission;
-//        scheduler.runTaskAsynchronously(this.plugin, () -> {
-//            final var rewardList = this.rewardsConnection.getRewardsTable().selectRewards(playerId, finalMission);
-//            if(rewardList.isEmpty()) {
-//                scheduler.runTask(this.plugin, () -> {
-//                    I18n.send(player, "command.acquire.empty", mission);
-//                    this.playerAcquiringRewards.remove(playerId);
-//                });
-//            } else {
-//                this.plugin.getSLF4JLogger().info("Player {} is acquiring {} rewards", playerId, rewardList.size());
-//                scheduler.runTask(this.plugin, () -> {
-//                    IntArrayList rewardIdList = new IntArrayList(rewardList.size());
-//                    ObjectArrayList<Component> outputMessages = new ObjectArrayList<>(16);
-//                    for (RewardDbModel reward : rewardList) {
-//                        Boolean distributeRet = reward.getReward().distribute(player, this.plugin, outputMessages);
-//                        if(distributeRet == null) {
-//                            this.plugin.getSLF4JLogger().warn("Player {} blocked acquire reward {}", playerId, reward.getId());
-//                            break;
-//                        } else {
-//                            if (distributeRet) {
-//                                rewardIdList.add(reward.getId());
-//                                I18n.send(player, "command.acquire.success", reward.getRewardName());
-//                            } else {
-//                                I18n.send(player, "command.acquire.failed", reward.getRewardName());
-//                            }
-//                        }
-//                        outputMessages.clear();
-//                    }
-//                    if(!rewardIdList.isEmpty()) {
-//                        scheduler.runTaskAsynchronously(this.plugin, () -> {
-//                            this.rewardsConnection.getRewardsTable().deleteRewardBatch(rewardIdList);
-//                            this.playerAcquiringRewards.remove(playerId);
-//                            this.plugin.getSLF4JLogger().info("Player {} has acquired {} rewards", playerId, rewardIdList.size());
-//                        });
-//                    }
-//                });
-//            }
-//        });
-//    }
-
-//    public void showPlayerRewards(Player player, @Nullable String mission, boolean notifyAcquire) {
-//        final UUID playerId = player.getUniqueId();
-//        final var scheduler = plugin.getServer().getScheduler();
-//        final String finalMission = "all".equals(mission) ? null : mission;
-//        scheduler.runTaskAsynchronously(this.plugin, () -> {
-//            final var rewardListCount = this.rewardsConnection.getRewardsTable().selectRewardsCount(playerId, finalMission);
-//            scheduler.runTaskLater(this.plugin, () -> {
-//                if(rewardListCount == 0) {
-//                    if(notifyAcquire) {
-//
-//                    } else {
-//                        if(finalMission == null) {
-//                            I18n.send(player, "command.listrewards.empty_all");
-//                        } else {
-//                            I18n.send(player, "command.listrewards.empty", finalMission);
-//                        }
-//                    }
-//                } else {
-//                    if(notifyAcquire) {
-//                        String command = PlaceholderAPIUtils.setPlaceholders(
-//                                player,
-//                                I18n.format(
-//                                        "message.mission.notify.command",
-//                                        finalMission == null ? "all" : finalMission
-//                                )
-//                        );
-//                        String msg = PlaceholderAPIUtils.setPlaceholders(
-//                                player,
-//                                finalMission == null ?
-//                                        I18n.format("command.listrewards.show_all", rewardListCount) :
-//                                        I18n.format("command.listrewards.show", rewardListCount, finalMission)
-//                        );
-//                        BaseComponent[] commandComponent = new ComponentBuilder()
-//                                .append(msg)
-//                                .append(command)
-//                                .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command))
-//                                .create();
-//                        player.spigot().sendMessage(new TextComponent(commandComponent));
-//                    } else {
-//                        if(finalMission == null) {
-//                            I18n.send(player, "command.listrewards.show_all", rewardListCount);
-//                        } else {
-//                            I18n.send(player, "command.listrewards.show", rewardListCount, finalMission);
-//                        }
-//                    }
-//                }
-//            }, notifyAcquire ? 10 : 1);
-//        });
-//    }
 
     public void onDailyReset(UUID playerId) {
         resetMission(true, false, false, playerId);

--- a/src/main/java/cat/nyaa/playtimetracker/PlayerRewardManager.java
+++ b/src/main/java/cat/nyaa/playtimetracker/PlayerRewardManager.java
@@ -1,7 +1,7 @@
 package cat.nyaa.playtimetracker;
 
 import cat.nyaa.playtimetracker.config.data.EcoRewardData;
-import cat.nyaa.playtimetracker.config.data.ISerializableExt;
+import cat.nyaa.playtimetracker.config.ISerializableExt;
 import cat.nyaa.playtimetracker.db.connection.RewardsConnection;
 import cat.nyaa.playtimetracker.db.model.RewardDbModel;
 import cat.nyaa.playtimetracker.db.tables.RewardsTable;
@@ -70,7 +70,7 @@ public class PlayerRewardManager {
         final var scheduler = this.plugin.getServer().getScheduler();
         final var logger = this.plugin.getSLF4JLogger();
         scheduler.runTaskAsynchronously(this.plugin, () -> {
-            final var rewardList = this.rewardsTable.selectRewards(player.getUniqueId(), missionName);
+            final var rewardList = this.rewardsTable.selectRewards(player.getUniqueId(), missionName, true);
             if(rewardList.isEmpty()) {
                 scheduler.runTask(this.plugin, () -> {
                     if(missionName == null) {

--- a/src/main/java/cat/nyaa/playtimetracker/command/CommandHandler.java
+++ b/src/main/java/cat/nyaa/playtimetracker/command/CommandHandler.java
@@ -7,6 +7,7 @@ import cat.nyaa.playtimetracker.*;
 import cat.nyaa.playtimetracker.command.sub.ResetCommand;
 import cat.nyaa.playtimetracker.db.model.TimeTrackerDbModel;
 import cat.nyaa.playtimetracker.utils.CommandUtils;
+import cat.nyaa.playtimetracker.utils.Constants;
 import cat.nyaa.playtimetracker.utils.TimeUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -14,12 +15,16 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
 public class CommandHandler extends CommandReceiver {
+
+    private static final Logger logger = Constants.getPluginLogger();
+
     private final I18n i18n;
     private final PlayTimeTracker plugin;
 
@@ -127,7 +132,7 @@ public class CommandHandler extends CommandReceiver {
                 var playerName = offlinePlayer.getName();
                 I18n.send(sender, "command.migration.insert", playerName == null ? "{" + rec_id + "}" : playerName);
             } catch (Exception e) {
-                e.printStackTrace();
+                logger.error("Error while migrating player data", e);
                 sender.sendMessage(e.getLocalizedMessage());
             }
             I18n.send(sender, "command.migration.finish");
@@ -177,39 +182,12 @@ public class CommandHandler extends CommandReceiver {
             I18n.send(sender, "command.only-player-can-do");
             return;
         }
-        PlayerRewardManager missionManager = plugin.getRewardManager();
-        if (missionManager == null) {
+        PlayerRewardManager rewardManager = plugin.getRewardManager();
+        if (rewardManager == null) {
             I18n.send(sender, "command.acquire.err");
             return;
         }
-        missionManager.executeDistributeRewardsAsync(player, "all".equals(missionName) ? null : missionName);
-//        Set<String> missionNameSet = missionManager.getAwaitingMissionNameSet(player);
-//        if (missionName.equals("all")) {
-//            if (missionNameSet.isEmpty()) {
-//                I18n.send(sender, "command.acquire.empty");
-//                return;
-//            }
-//            missionNameSet.forEach(
-//                    (mission) -> {
-//                        if (missionManager.completeMission(player, mission)) {
-//                            I18n.send(sender, "command.acquire.success", mission);
-//                        } else {
-//                            I18n.send(sender, "command.acquire.failed", mission);
-//                        }
-//                    }
-//            );
-//
-//        } else {
-//            if (!missionNameSet.contains(missionName)) {
-//                I18n.send(sender, "command.acquire.not_found", missionName);
-//            } else {
-//                if (missionManager.completeMission(player, missionName)) {
-//                    I18n.send(sender, "command.acquire.success", missionName);
-//                } else {
-//                    I18n.send(sender, "command.acquire.failed", missionName);
-//                }
-//            }
-//        }
+        rewardManager.executeDistributeRewardsAsync(player, "all".equals(missionName) ? null : missionName);
     }
 
     @SubCommand(value = "reload", permission = "ptt.command.reload")

--- a/src/main/java/cat/nyaa/playtimetracker/config/DatabaseConfig.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/DatabaseConfig.java
@@ -2,7 +2,6 @@ package cat.nyaa.playtimetracker.config;
 
 import cat.nyaa.nyaacore.configuration.FileConfigure;
 import cat.nyaa.nyaacore.orm.backends.BackendConfig;
-import cat.nyaa.playtimetracker.PlayTimeTracker;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class DatabaseConfig extends FileConfigure {

--- a/src/main/java/cat/nyaa/playtimetracker/config/ISerializableExt.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/ISerializableExt.java
@@ -1,4 +1,4 @@
-package cat.nyaa.playtimetracker.config.data;
+package cat.nyaa.playtimetracker.config;
 
 import cat.nyaa.nyaacore.configuration.ISerializable;
 

--- a/src/main/java/cat/nyaa/playtimetracker/config/PTTConfiguration.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/PTTConfiguration.java
@@ -1,7 +1,6 @@
 package cat.nyaa.playtimetracker.config;
 
 import cat.nyaa.nyaacore.configuration.PluginConfigure;
-import cat.nyaa.playtimetracker.PlayTimeTracker;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.time.ZoneId;

--- a/src/main/java/cat/nyaa/playtimetracker/config/data/CommandRewardData.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/data/CommandRewardData.java
@@ -1,0 +1,26 @@
+package cat.nyaa.playtimetracker.config.data;
+
+import cat.nyaa.playtimetracker.config.ISerializableExt;
+
+import java.util.List;
+
+public class CommandRewardData implements ISerializableExt {
+
+    @Serializable(name = "pre-command")
+    public String preCommand = "";
+
+    @Serializable
+    public String command = "";
+
+    {
+        command = "/tell %%player_name%% hello, world!";
+    }
+
+    public CommandRewardData() {
+    }
+
+    @Override
+    public boolean validate(List<String> outputError) {
+        return !command.isBlank();
+    }
+}

--- a/src/main/java/cat/nyaa/playtimetracker/config/data/EcoRewardData.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/data/EcoRewardData.java
@@ -1,6 +1,6 @@
 package cat.nyaa.playtimetracker.config.data;
 
-import cat.nyaa.nyaacore.configuration.ISerializable;
+import cat.nyaa.playtimetracker.config.ISerializableExt;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -24,6 +24,8 @@ public class EcoRewardData implements ISerializableExt {
     public String vault = SYSTEM_VAULT;
     @Serializable
     public double amount = 0.0;
+    @Serializable(name = "sync-ref-cache-time")
+    public long syncRefCacheTime = 256 * 50; // sync ref vault by cache its value, keeps $value milliseconds; default set to 4 * 64 gt
 
     private @Nullable UUID refVaultUUID = null;
     private @Nullable UUID vaultUUID = null;

--- a/src/main/java/cat/nyaa/playtimetracker/config/data/MissionData.java
+++ b/src/main/java/cat/nyaa/playtimetracker/config/data/MissionData.java
@@ -1,14 +1,12 @@
 package cat.nyaa.playtimetracker.config.data;
 
-import cat.nyaa.nyaacore.configuration.ISerializable;
-import cat.nyaa.nyaacore.utils.ItemStackUtils;
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
+import cat.nyaa.playtimetracker.config.ISerializableExt;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
 public class MissionData implements ISerializableExt {
+
     @Serializable
     public List<String> group = new ArrayList<>();
     @Serializable
@@ -27,6 +25,7 @@ public class MissionData implements ISerializableExt {
 
     {
         rewardList.put("reward1", new EcoRewardData());
+        rewardList.put("reward2", new CommandRewardData());
     }
 
     private @Nullable List<ISerializableExt> sortedRewardList = null;

--- a/src/main/java/cat/nyaa/playtimetracker/db/connection/CompletedMissionConnection.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/connection/CompletedMissionConnection.java
@@ -14,7 +14,7 @@ public class CompletedMissionConnection {
     private final CompletedMissionTable completedMissionTable;
 
     public CompletedMissionConnection(HikariDataSource ds, Plugin plugin) {
-        this.completedMissionTable = new CompletedMissionTable(ds, plugin.getSLF4JLogger());
+        this.completedMissionTable = new CompletedMissionTable(ds);
         this.completedMissionTable.tryCreateTable(plugin);
     }
 
@@ -29,14 +29,14 @@ public class CompletedMissionConnection {
     public void writeMissionCompleted(UUID playerUniqueId, String missionName, long lastCompletedTime) {
         synchronized (CompletedMissionConnection.class) {
             var rs = completedMissionTable.select(playerUniqueId, missionName);
-            if (rs.size() == 0) {
+            if (rs.isEmpty()) {
                 CompletedMissionDbModel newModel = new CompletedMissionDbModel();
                 newModel.setMissionName(missionName);
                 newModel.setLastCompletedTime(lastCompletedTime);
                 newModel.setPlayerUniqueId(playerUniqueId);
                 completedMissionTable.insert(newModel);
             } else {
-                var model = rs.get(0);
+                var model = rs.getFirst();
                 model.setLastCompletedTime(lastCompletedTime);
                 completedMissionTable.updatePlayer(model, model.getId());
             }
@@ -46,8 +46,8 @@ public class CompletedMissionConnection {
     @Nullable
     public CompletedMissionDbModel getPlayerCompletedMission(UUID playerUniqueId, String missionName) {
         var rs = completedMissionTable.select(playerUniqueId, missionName);
-        if (rs.size() > 0) {
-            return rs.get(0);
+        if (!rs.isEmpty()) {
+            return rs.getFirst();
         }
         return null;
     }

--- a/src/main/java/cat/nyaa/playtimetracker/db/connection/RewardsConnection.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/connection/RewardsConnection.java
@@ -10,7 +10,7 @@ public class RewardsConnection {
     
     public RewardsConnection(HikariDataSource ds, Plugin plugin) {
         this.plugin = plugin;
-        this.rewardsTable = new RewardsTable(ds, plugin.getSLF4JLogger());
+        this.rewardsTable = new RewardsTable(ds);
         this.rewardsTable.tryCreateTable(plugin);
     }
 

--- a/src/main/java/cat/nyaa/playtimetracker/db/connection/TimeTrackerConnection.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/connection/TimeTrackerConnection.java
@@ -20,7 +20,7 @@ public final class TimeTrackerConnection {
 
     public TimeTrackerConnection(HikariDataSource ds, Plugin plugin) {
         this.plugin = plugin;
-        this.timeTrackerTable = new TimeTrackerTable(ds, plugin.getSLF4JLogger());
+        this.timeTrackerTable = new TimeTrackerTable(ds);
         this.timeTrackerTable.tryCreateTable(plugin);
     }
 

--- a/src/main/java/cat/nyaa/playtimetracker/db/tables/CompletedMissionTable.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/tables/CompletedMissionTable.java
@@ -1,16 +1,15 @@
 package cat.nyaa.playtimetracker.db.tables;
 
-import cat.nyaa.nyaacore.orm.BundledSQLUtils;
 import cat.nyaa.playtimetracker.db.DatabaseManager;
 import cat.nyaa.playtimetracker.db.model.CompletedMissionDbModel;
+import cat.nyaa.playtimetracker.db.utils.DatabaseUtils;
+import cat.nyaa.playtimetracker.utils.Constants;
 import com.zaxxer.hikari.HikariDataSource;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,25 +17,18 @@ import java.util.UUID;
 
 public class CompletedMissionTable {
 
+    private static final Logger logger = Constants.getPluginLogger();
     public static final String TABLE_NAME = "completed";
     private final HikariDataSource ds;
-    private final Logger logger;
 
-    public CompletedMissionTable(HikariDataSource ds, Logger logger) {
+    public CompletedMissionTable(HikariDataSource ds) {
         this.ds = ds;
-        this.logger = logger;
     }
 
     public boolean tryCreateTable(Plugin plugin) {
         synchronized (DatabaseManager.lock) {
-            try (var conn = this.ds.getConnection()) {
-                final String[] types = { "TABLE" };
-                ResultSet rs = conn.getMetaData().getTables(null, null, TABLE_NAME, types);
-                if(rs.next()){
-                    return false;
-                }
-                BundledSQLUtils.queryBundledAs(plugin, conn, "create_table_completed.sql", null, null);
-                return true;
+            try {
+                return DatabaseUtils.tryCreateTable(ds, TABLE_NAME, "create_table_completed.sql", plugin);
             } catch (SQLException e) {
                 logger.error("Failed to create {}", TABLE_NAME, e);
                 return false;

--- a/src/main/java/cat/nyaa/playtimetracker/db/tables/RewardsTable.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/tables/RewardsTable.java
@@ -1,23 +1,24 @@
 package cat.nyaa.playtimetracker.db.tables;
 
-import cat.nyaa.nyaacore.orm.BundledSQLUtils;
 import cat.nyaa.playtimetracker.db.DatabaseManager;
 import cat.nyaa.playtimetracker.db.model.RewardDbModel;
+import cat.nyaa.playtimetracker.db.utils.DatabaseUtils;
 import cat.nyaa.playtimetracker.reward.IReward;
+import cat.nyaa.playtimetracker.utils.Constants;
 import com.zaxxer.hikari.HikariDataSource;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterable;
+import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
-import java.sql.ResultSet;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -26,102 +27,55 @@ import java.util.UUID;
 
 public class RewardsTable {
 
+    private final static Logger logger = Constants.getPluginLogger();
+
     public static final String TABLE_NAME = "rewards";
 
     public static final int HEAD_MAGIC = 0x505454FE;
 
     private final HikariDataSource ds;
-    private final Logger logger;
 
-    public RewardsTable(HikariDataSource ds, Logger logger) {
+    public RewardsTable(HikariDataSource ds) {
         this.ds = ds;
-        this.logger = logger;
     }
 
     private static ByteOutputStreamEx serializeReward(IReward reward, int capacity) throws Exception {
         ByteOutputStreamEx bos = new ByteOutputStreamEx(capacity);
-        try (bos) {
-            byte[] intBuffer = new byte[4];
-
-            intBuffer[0] = (byte) ((HEAD_MAGIC >>> 24) & 0xFF);
-            intBuffer[1] = (byte) ((HEAD_MAGIC >>> 16) & 0xFF);
-            intBuffer[2] = (byte) ((HEAD_MAGIC >>> 8) & 0xFF);
-            intBuffer[3] = (byte) ((HEAD_MAGIC) & 0xFF);
-            bos.write(intBuffer);
-
+        try (DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(HEAD_MAGIC);
             byte[] className = reward.getClass().getName().getBytes(StandardCharsets.UTF_8);
-            final int classNameLength = className.length;
-            intBuffer[0] = (byte) ((classNameLength >>> 24) & 0xFF);
-            intBuffer[1] = (byte) ((classNameLength >>> 16) & 0xFF);
-            intBuffer[2] = (byte) ((classNameLength >>> 8) & 0xFF);
-            intBuffer[3] = (byte) ((classNameLength) & 0xFF);
-            bos.write(intBuffer);
-            bos.write(className);
-
-            intBuffer[0] = 0;
-            intBuffer[1] = 0;
-            intBuffer[2] = 0;
-            intBuffer[3] = 0;
-            bos.write(intBuffer);
-
-            reward.serialize(bos);
+            dos.writeInt(className.length);
+            dos.write(className);
+            dos.writeInt(0);
+            reward.serialize(dos);
         }
         return bos;
     }
 
-    private static IReward deserializeReward(InputStream inputStream) throws Exception {
-        try (inputStream) {
-            byte[] intBuffer = new byte[4];
-
-            if(inputStream.read(intBuffer) < 4) {
-                throw new IOException("invalid head magic length");
-            }
-            int headMagic = ((intBuffer[0] & 0xFF) << 24)
-                          | ((intBuffer[1] & 0xFF) << 16)
-                          | ((intBuffer[2] & 0xFF) << 8)
-                          | (intBuffer[3] & 0xFF);
-            if (headMagic != HEAD_MAGIC) {
-                throw new ParseException("Invalid head magic", 0);
-            }
-
-            if(inputStream.read(intBuffer) < 4) {
-                throw new IOException("invalid class name length");
-            }
-            int classNameLength = ((intBuffer[0] & 0xFF) << 24)
-                                | ((intBuffer[1] & 0xFF) << 16)
-                                | ((intBuffer[2] & 0xFF) << 8)
-                                | (intBuffer[3] & 0xFF);
-            if(classNameLength < 0) {
-                throw new ParseException("Invalid class name length", 4);
-            }
-            byte[] classNameBuffer = new byte[classNameLength];
-            if(inputStream.read(classNameBuffer) < 0) {
-                throw new IOException("invalid class name");
-            }
-            String className = new String(classNameBuffer, StandardCharsets.UTF_8);
-            Class<?> clazz = Class.forName(className);
-            Constructor<?> constructor = clazz.getDeclaredConstructor();
-            IReward reward = (IReward) constructor.newInstance();
-
-            if(inputStream.skip(4) < 4) {
-                throw new IOException("invalid format");
-            }
-
-            reward.deserialize(inputStream);
-            return reward;
+    private static IReward deserializeReward(DataInputStream dis) throws Exception {
+        int headMagic = dis.readInt();
+        if (headMagic != HEAD_MAGIC) {
+            throw new ParseException("Invalid head magic", 0);
         }
+        int classNameLength = dis.readInt();
+        if(classNameLength < 0) {
+            throw new ParseException("Invalid class name length", 4);
+        }
+        byte[] classNameBuffer = new byte[classNameLength];
+        dis.readFully(classNameBuffer);
+        String className = new String(classNameBuffer, StandardCharsets.UTF_8);
+        Class<?> clazz = Class.forName(className);
+        Constructor<?> constructor = clazz.getDeclaredConstructor();
+        IReward reward = (IReward) constructor.newInstance();
+        final int reserved = dis.readInt();
+        reward.deserialize(dis);
+        return reward;
     }
 
     public boolean tryCreateTable(Plugin plugin) {
         synchronized (DatabaseManager.lock) {
-            try (var conn = this.ds.getConnection()) {
-                final String[] types = { "TABLE" };
-                ResultSet rs = conn.getMetaData().getTables(null, null, TABLE_NAME, types);
-                if(rs.next()){
-                    return false;
-                }
-                BundledSQLUtils.queryBundledAs(plugin, conn, "create_table_rewards.sql", null, null);
-                return true;
+            try {
+                return DatabaseUtils.tryCreateTable(ds, TABLE_NAME, "create_table_rewards.sql", plugin);
             } catch (SQLException e) {
                 logger.error("Failed to create {}", TABLE_NAME, e);
                 return false;
@@ -188,22 +142,27 @@ public class RewardsTable {
     public void deleteRewardBatch(IntIterable ids) {
         synchronized (DatabaseManager.lock) {
             try (var conn = this.ds.getConnection()) {
-                try (var ps = conn.prepareStatement("DELETE FROM " + TABLE_NAME + " WHERE id = ?")) {
-                    var it = ids.iterator();
-                    while (it.hasNext()) {
-                        ps.setInt(1, it.nextInt());
-                        ps.addBatch();
-                    }
-                    ps.executeBatch();
-                }
+                deleteRewardBatch0(ids, conn);
             } catch (SQLException e) {
                 logger.error("Failed to delete from {}", TABLE_NAME, e);
             }
         }
     }
 
-    public List<RewardDbModel> selectRewards(UUID playerUniqueID, @Nullable String rewardName){
+    private static void deleteRewardBatch0(IntIterable ids, Connection conn) throws SQLException {
+        try (var ps = conn.prepareStatement("DELETE FROM " + TABLE_NAME + " WHERE id = ?")) {
+            var it = ids.iterator();
+            while (it.hasNext()) {
+                ps.setInt(1, it.nextInt());
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    public List<RewardDbModel> selectRewards(UUID playerUniqueID, @Nullable String rewardName, boolean autoRemoveOnFail) {
         synchronized (DatabaseManager.lock) {
+            IntList ids = null;
             try (var conn = this.ds.getConnection()) {
                 String sql;
                 if (rewardName == null) {
@@ -224,7 +183,20 @@ public class RewardsTable {
                             reward.completedTime = rs.getLong(2);
                             reward.playerUniqueID = UUID.fromString(rs.getString(3));
                             reward.rewardName = rs.getString(4);
-                            reward.reward = deserializeReward(rs.getBinaryStream(5));
+                            InputStream inputStream = rs.getBinaryStream(5);
+                            try(var dis = new DataInputStream(inputStream)) {
+                                reward.reward = deserializeReward(dis);
+                            } catch (Exception e) {
+                                logger.error("Failed to deserialize", e);
+                                if (autoRemoveOnFail) {
+                                    if (ids == null) {
+                                        ids = new IntArrayList();
+                                    }
+                                    ids.add(reward.id);
+                                    logger.warn("Remove invalid reward {}", reward.id);
+                                }
+                                continue;
+                            }
                             rewards.add(reward);
                         }
                         return rewards;
@@ -233,9 +205,14 @@ public class RewardsTable {
             } catch (SQLException e) {
                 logger.error("Failed to select from {}", TABLE_NAME, e);
                 return null;
-            } catch (Exception e) {
-                logger.error("Failed to deserialize", e);
-                return null;
+            } finally {
+                if(autoRemoveOnFail && ids != null) {
+                    try (var conn = this.ds.getConnection()) {
+                        deleteRewardBatch0(ids, conn);
+                    } catch (SQLException e) {
+                        logger.error("Failed to delete invalid from {}", TABLE_NAME, e);
+                    }
+                }
             }
         }
     }

--- a/src/main/java/cat/nyaa/playtimetracker/db/tables/TimeTrackerTable.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/tables/TimeTrackerTable.java
@@ -1,14 +1,14 @@
 package cat.nyaa.playtimetracker.db.tables;
 
-import cat.nyaa.nyaacore.orm.BundledSQLUtils;
 import cat.nyaa.playtimetracker.db.DatabaseManager;
 import cat.nyaa.playtimetracker.db.model.TimeTrackerDbModel;
+import cat.nyaa.playtimetracker.db.utils.DatabaseUtils;
+import cat.nyaa.playtimetracker.utils.Constants;
 import com.zaxxer.hikari.HikariDataSource;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -17,26 +17,19 @@ import java.util.UUID;
 
 public class TimeTrackerTable {
 
+    private static final Logger logger = Constants.getPluginLogger();
     public static final String TABLE_NAME = "time";
 
     private final HikariDataSource ds;
-    private final Logger logger;
 
-    public TimeTrackerTable(HikariDataSource ds, Logger logger) {
+    public TimeTrackerTable(HikariDataSource ds) {
         this.ds = ds;
-        this.logger = logger;
     }
 
     public boolean tryCreateTable(Plugin plugin) {
         synchronized (DatabaseManager.lock) {
-            try (var conn = this.ds.getConnection()) {
-                final String[] types = { "TABLE" };
-                ResultSet rs = conn.getMetaData().getTables(null, null, TABLE_NAME, types);
-                if(rs.next()){
-                    return false;
-                }
-                BundledSQLUtils.queryBundledAs(plugin, conn, "create_table_time.sql", null, null);
-                return true;
+            try {
+                return DatabaseUtils.tryCreateTable(ds, TABLE_NAME, "create_table_time.sql", plugin);
             } catch (SQLException e) {
                 logger.error("Failed to create {}", TABLE_NAME, e);
                 return false;

--- a/src/main/java/cat/nyaa/playtimetracker/db/utils/DatabaseUtils.java
+++ b/src/main/java/cat/nyaa/playtimetracker/db/utils/DatabaseUtils.java
@@ -1,0 +1,39 @@
+package cat.nyaa.playtimetracker.db.utils;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.plugin.Plugin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DatabaseUtils {
+
+    private static final String[] TYPES_TABLE = { "TABLE" };
+
+    public static boolean tryCreateTable(HikariDataSource ds, String tableName, String fileCreateTableSql, Plugin plugin) throws SQLException {
+        try (var conn = ds.getConnection()) {
+            ResultSet rs = conn.getMetaData().getTables(null, null, tableName, TYPES_TABLE);
+            if(rs.next()){
+                return false;
+            }
+            var path = "sql/" + fileCreateTableSql;
+            var sqlInputStream = plugin.getResource(path);
+            if(sqlInputStream == null){
+                throw new SQLException("cannot find sql file from resource: " + path);
+            }
+            String sql;
+            try(sqlInputStream){
+                byte[] bytes = sqlInputStream.readAllBytes();
+                sql = new String(bytes, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new SQLException("cannot read sql file from resource: " + path, e);
+            }
+            try(var ps = conn.prepareStatement(sql)){
+                ps.execute();
+            }
+            return true;
+        }
+    }
+}

--- a/src/main/java/cat/nyaa/playtimetracker/listener/PTTListener.java
+++ b/src/main/java/cat/nyaa/playtimetracker/listener/PTTListener.java
@@ -42,18 +42,27 @@ public class PTTListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (PlayTimeTracker.getInstance() != null) {
-            if (PlayTimeTracker.getInstance().getMissionManager() != null) {
-                PlayTimeTracker.getInstance().getMissionManager().checkPlayerMission(event.getPlayer());
+        var plugin = PlayTimeTracker.getInstance();
+        if (plugin != null) {
+            var missionManager = plugin.getMissionManager();
+            if (missionManager != null) {
+                missionManager.checkPlayerMission(event.getPlayer());
             }
-            if (PlayTimeTracker.getInstance().getTimeRecordManager() != null) {
-                PlayTimeTracker.getInstance().getTimeRecordManager().addPlayer(event.getPlayer());
+            var timeRecordManager = plugin.getTimeRecordManager();
+            if (timeRecordManager != null) {
+                timeRecordManager.addPlayer(event.getPlayer());
             }
-            if (PlayTimeTracker.getInstance().getAfkManager() != null) {
-                PlayTimeTracker.getInstance().getAfkManager().addPlayer(event.getPlayer());
+            var afkManager = plugin.getAfkManager();
+            if (afkManager != null) {
+                afkManager.addPlayer(event.getPlayer());
             }
-            if(PlayTimeTracker.getInstance().getRewardManager() != null){
-                PlayTimeTracker.getInstance().getRewardManager().executeRewardsAutoCheckAsync(event.getPlayer(), 10);
+            var rewardManager = plugin.getRewardManager();
+            if(rewardManager != null){
+                int delay = 10;
+                if(missionManager != null){
+                    delay = missionManager.getMissionConfig().loginCheckDelayTicks;
+                }
+                rewardManager.executeRewardsAutoCheckAsync(event.getPlayer(), delay);
             }
         }
     }

--- a/src/main/java/cat/nyaa/playtimetracker/reward/CommandReward.java
+++ b/src/main/java/cat/nyaa/playtimetracker/reward/CommandReward.java
@@ -1,0 +1,78 @@
+package cat.nyaa.playtimetracker.reward;
+
+import cat.nyaa.playtimetracker.config.data.CommandRewardData;
+import cat.nyaa.playtimetracker.utils.PlaceholderAPIUtils;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CommandReward implements IReward {
+
+    private final @Nullable CommandRewardData cfg;
+    private @Nullable String command;
+
+    public CommandReward() {
+        this.cfg = null;
+        this.command = null;
+    }
+
+    public CommandReward(@Nullable CommandRewardData cfg) {
+        this.cfg = cfg;
+        this.command = null;
+    }
+
+    @Override
+    public boolean prepare(String rewardName, long completedTime, Player player, Plugin plugin) {
+        if(this.cfg == null) {
+            return false;
+        }
+        if(this.cfg.preCommand != null && !this.cfg.preCommand.isBlank()) {
+            var server = plugin.getServer();
+            var command = PlaceholderAPIUtils.setPlaceholders(player, this.cfg.preCommand);
+            return server.dispatchCommand(server.getConsoleSender(), command);
+        }
+        return true;
+    }
+
+    @Override
+    public Boolean distribute(Player player, Plugin plugin, List<Component> outputMessages) {
+        if(this.command == null) {
+            return false;
+        }
+        var server = plugin.getServer();
+        var command = PlaceholderAPIUtils.setPlaceholders(player, this.command);
+        return server.dispatchCommand(server.getConsoleSender(), command);
+    }
+
+    @Override
+    public void serialize(OutputStream outputStream) throws Exception {
+        if(this.cfg == null) {
+            throw new Exception("CommandRewardData is null");
+        }
+        if(this.cfg.command == null || this.cfg.command.isBlank()) {
+            throw new Exception("command is null or empty");
+        }
+        byte[] bytes = this.cfg.command.getBytes(StandardCharsets.UTF_8);
+        DataOutputStream dos = IReward.fromOutputStream(outputStream);
+        dos.writeInt(bytes.length);
+        dos.write(bytes);
+        dos.flush();
+    }
+
+    @Override
+    public void deserialize(InputStream inputStream) throws Exception {
+        DataInputStream dis = IReward.fromInputStream(inputStream);
+        int length = dis.readInt();
+        if(length <= 0) {
+            throw new Exception("Invalid command length");
+        }
+        byte[] bytes = new byte[length];
+        dis.readFully(bytes);
+        this.command = new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/cat/nyaa/playtimetracker/reward/IReward.java
+++ b/src/main/java/cat/nyaa/playtimetracker/reward/IReward.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
@@ -47,4 +49,19 @@ public interface IReward {
      * @throws Exception if any error occurs
      */
     void deserialize(InputStream inputStream) throws Exception;
+
+
+    static DataOutputStream fromOutputStream(OutputStream outputStream) {
+        if(outputStream instanceof DataOutputStream dataOutputStream) {
+            return dataOutputStream;
+        }
+        return new DataOutputStream(outputStream);
+    }
+
+    static DataInputStream fromInputStream(InputStream inputStream) {
+        if(inputStream instanceof DataInputStream dataInputStream) {
+            return dataInputStream;
+        }
+        return new DataInputStream(inputStream);
+    }
 }

--- a/src/main/java/cat/nyaa/playtimetracker/utils/Constants.java
+++ b/src/main/java/cat/nyaa/playtimetracker/utils/Constants.java
@@ -1,0 +1,31 @@
+package cat.nyaa.playtimetracker.utils;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Constants {
+
+    public static String PLUGIN_NAME = "";
+
+    public static String PLUGIN_LOGGER_NAME = PLUGIN_NAME;
+
+
+    public static void init(final JavaPlugin plugin) {
+        PLUGIN_NAME = plugin.getName();
+        PLUGIN_LOGGER_NAME = plugin.getSLF4JLogger().getName();
+    }
+
+    public static Logger getPluginLogger() {
+        if(!PLUGIN_LOGGER_NAME.isEmpty()) {
+            return LoggerFactory.getLogger(PLUGIN_LOGGER_NAME);
+        } else {
+            var stack = Thread.currentThread().getStackTrace();
+            // [0] is getStackTrace, [1] is getPluginLogger, [2] is the caller
+            var name = stack[2].getClassName();
+            var logger = LoggerFactory.getLogger(name);
+            logger.warn("Uninitialized PLUGIN_LOGGER_NAME, using default logger \"{}\"", name);
+            return logger;
+        }
+    }
+}

--- a/src/test/java/cat/nyaa/playtimetracker/DemoInvalidReward.java
+++ b/src/test/java/cat/nyaa/playtimetracker/DemoInvalidReward.java
@@ -1,0 +1,47 @@
+package cat.nyaa.playtimetracker;
+
+import cat.nyaa.playtimetracker.reward.IReward;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public class DemoInvalidReward implements IReward {
+
+    public boolean allowSerialize = false;
+
+    public boolean allowDeserialize = false;
+
+    public DemoInvalidReward(boolean allowSerialize, boolean allowDeserialize) {
+        this.allowSerialize = allowSerialize;
+        this.allowDeserialize = allowDeserialize;
+    }
+
+
+    @Override
+    public boolean prepare(String rewardName, long completedTime, Player player, Plugin plugin) {
+        return true;
+    }
+
+    @Override
+    public Boolean distribute(Player player, Plugin plugin, List<Component> outputMessages) {
+        return null;
+    }
+
+    @Override
+    public void serialize(OutputStream outputStream) throws Exception {
+        if(!allowSerialize) {
+            throw new Exception("Not allowed to serialize");
+        }
+    }
+
+    @Override
+    public void deserialize(InputStream inputStream) throws Exception {
+        if(!allowDeserialize) {
+            throw new Exception("Not allowed to deserialize");
+        }
+    }
+}

--- a/src/test/java/cat/nyaa/playtimetracker/DemoPTT.java
+++ b/src/test/java/cat/nyaa/playtimetracker/DemoPTT.java
@@ -29,6 +29,11 @@ public class DemoPTT extends MockPlugin implements IEconomyCoreProvider {
 
         public double systemBalance = SYSTEM_BALANCE;
 
+        public void init() {
+            balances.clear();
+            systemBalance = SYSTEM_BALANCE;
+        }
+
         @Override
         public TransactionResult playerTransfer(UUID uuid, UUID uuid1, double v) {
             throw new UnsupportedOperationException();

--- a/src/test/java/cat/nyaa/playtimetracker/config/TestConfig.java
+++ b/src/test/java/cat/nyaa/playtimetracker/config/TestConfig.java
@@ -3,7 +3,6 @@ package cat.nyaa.playtimetracker.config;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.MockPlugin;
 import be.seeseemelk.mockbukkit.ServerMock;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
### 0.10-alpha.3

- [Fix] When use transfer type ECO Reward, if there are multiple players complete the mission at the same time, the reward amount decreases by the order of player list.

- [Feature]  (As the [Fix] Above) Add configuration in `mission.yml` for transfer type ECO reward: 

  `missions[].reward-list[].sync-ref-cache-time` 

  to make sure players completing the mission within `sync-ref-cache-time` get the same reward amount (that is, use the same reference vault value).

  The time unit is milliseconds. Default is 12800 (12.8s = 4 * 64gt). Set to zero or `-1` to disable this feature.

- [Feature] Add Command Rewards. Now you can execute a command when a mission is completed and a reward is acquired.

- [Feature] Add configuration in `mission.yml` for later send information of awaiting rewards when login:
  
  `login-check-delay-ticks`

  to make it possible to show this information at the end of login information. The time unit is ticks. Default is 20 (1s).

- [Tech] When distributing rewards, database will delete invalid records so that it will not occupy player's rewards list forever.
